### PR TITLE
Fix Dependabot security alerts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import AutoImport from "astro-auto-import";
-import { defineConfig, squooshImageService } from "astro/config";
+import { defineConfig } from "astro/config";
 import remarkCollapse from "remark-collapse";
 import remarkToc from "remark-toc";
 import config from "./src/config/config.json";
@@ -13,9 +13,6 @@ export default defineConfig({
   site: config.site.base_url ? config.site.base_url : "http://examplesite.com",
   base: config.site.base_path ? config.site.base_path : "/",
   trailingSlash: config.site.trailing_slash ? "always" : "ignore",
-  image: {
-    service: squooshImageService(),
-  },
   integrations: [
     react(),
     sitemap(),
@@ -51,6 +48,5 @@ export default defineConfig({
       theme: "one-dark-pro",
       wrap: true,
     },
-    extendDefaultPlugins: true,
   },
 });

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "format": "prettier -w ./src"
   },
   "dependencies": {
-    "@astrojs/mdx": "^3.1.3",
-    "@astrojs/react": "^3.6.2",
-    "@astrojs/rss": "^4.0.7",
-    "@astrojs/sitemap": "^3.1.6",
+    "@astrojs/mdx": "^4.3.13",
+    "@astrojs/react": "^4.4.2",
+    "@astrojs/rss": "^4.0.15",
+    "@astrojs/sitemap": "^3.7.0",
     "@astrojs/tailwind": "^5.1.0",
     "aos": "^2.3.4",
-    "astro": "^4.13.4",
+    "astro": "^5.18.0",
     "astro-auto-import": "^0.4.2",
     "astro-font": "^0.1.81",
     "date-fns": "^3.6.0",
@@ -35,7 +35,7 @@
     "react-lite-youtube-embed": "^2.4.0",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
-    "swiper": "^11.1.9"
+    "swiper": "^12.1.2"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",


### PR DESCRIPTION
## Summary
- Upgraded **astro** 4.16.19 → 5.18.0 and **swiper** 11.2.10 → 12.1.2
- Bumped companion packages (@astrojs/mdx, @astrojs/react) for Astro 5 compatibility
- Resolved 6 vulnerabilities → **0 vulnerabilities**

## Changes
- `package.json` / `package-lock.json`: Major version bumps for astro (4→5) and swiper (11→12)
- `astro.config.mjs`: Removed deprecated `squooshImageService()` (dropped in Astro 5) and `extendDefaultPlugins` option

## Verification
- `npm audit` reports 0 vulnerabilities
- `npm run build` passes (15 pages built successfully)

## Test plan
- [ ] Verify site builds in CI
- [ ] Spot-check deployed pages for layout/functionality regressions from Astro 5 migration
- [ ] Verify Swiper carousels still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)